### PR TITLE
Restucture transaction page and index 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,4 +59,4 @@ repos:
     rev: "v3.0.3"
     hooks:
       - id: prettier
-        types_or: ["css", "javascript", "html"]
+        types_or: ["css", "javascript"]

--- a/src/htmx_fastapi/main.py
+++ b/src/htmx_fastapi/main.py
@@ -35,7 +35,15 @@ def favicon() -> fastapi.Response:
 
 
 @app.get("/transactions")
-def transactions(
+def transactions(request: fastapi.Request) -> fastapi.Response:
+    """Page view for transactions."""
+    context = {"request": request}
+
+    return template.TemplateResponse("transaction/index.html", context)
+
+
+@app.get("/transaction/table")
+def transaction_table(
     request: fastapi.Request,
     date_since: str | None = None,
     date_until: str | None = None,
@@ -44,7 +52,7 @@ def transactions(
     """
     Return partial HTML for transactions between `since` and `until`.
 
-    if `since` is None, default one year ago
+    if `since` is None, default 90 days ago
     if `until` is None, default now
     """
     now = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -61,7 +69,7 @@ def transactions(
         "date_until": date_until,
     }
 
-    return template.TemplateResponse("transaction/index.html", context)
+    return template.TemplateResponse("transaction/partial/table.html", context)
 
 
 @app.get("/transaction/{transaction_id}")

--- a/template/index.html
+++ b/template/index.html
@@ -1,12 +1,7 @@
-{% extends "_shared_base.html" %} {% block content %}
+{% extends "_shared_base.html" %}
+{% block content %}
+<h1>Example Main Index</h1>
 <div class="container">
-  <div
-    id="transactionTable"
-    hx-get="/transactions"
-    hx-trigger="load"
-    hx-swap="innerHTML"
-  >
-    {% include "transaction/index.html" with context %}
-  </div>
+  <a href="/transactions">Transactions Page</a>
 </div>
 {% endblock %}

--- a/template/transaction/index.html
+++ b/template/transaction/index.html
@@ -1,18 +1,8 @@
-{% import 'transaction/partial/row.html' as rows %} {% include
-'transaction/partial/daterange.html' with context %}
-<table id="transaction-table">
-  <thead>
-    <tr>
-      <th>Date</th>
-      <th>Description</th>
-      <th>Amount</th>
-      <th>&nbsp;</th>
-      <th>&nbsp;</th>
-    </tr>
-  </thead>
-  <tbody hx-target="closest tr" hx-swap="outerHTML">
-    {% if transactions %} {% for transaction in transactions %} {{
-    rows.transaction_row(transaction.tid, transaction.date,
-    transaction.description, transaction.amount) }} {% endfor %} {% endif %}
-  </tbody>
-</table>
+{% extends "_shared_base.html" %}
+{% block content %}
+<h1>Transactions Example Page</h1>
+
+<div id="transaction_table" hx-get="transaction/table" hx-trigger="load" hx-swap="innerHTML">
+  {% include 'transaction/partial/table.html' with context %}
+</div>
+{% endblock %}

--- a/template/transaction/partial/daterange.html
+++ b/template/transaction/partial/daterange.html
@@ -4,8 +4,8 @@
     type="date"
     name="date_since"
     value="{{ date_since }}"
-    hx-get="/transactions"
-    hx-target="#transactionTable"
+    hx-get="/transaction/table"
+    hx-target="#transaction_table"
     hx-trigger="change"
     hx-include="closest div"
   />
@@ -14,8 +14,8 @@
     type="date"
     name="date_until"
     value="{{ date_until }}"
-    hx-get="/transactions"
-    hx-target="#transactionTable"
+    hx-get="/transaction/table"
+    hx-target="#transaction_table"
     hx-trigger="change"
     hx-include="closest div"
   />

--- a/template/transaction/partial/row.html
+++ b/template/transaction/partial/row.html
@@ -1,7 +1,7 @@
 {% macro transaction_row(tid, date, description, amount) -%}
 <tr>
   <td>{{ date }}</td>
-  <td>{{ description }}</td>
+  <td hx-get="transaction/{{ tid }}/edit" hx-trigger="click">{{ description }}</td>
   <td>{{ amount | to_dollars }}</td>
   <td>
     <button type="submit" hx-get="/transaction/{{ tid }}/edit">Edit</button>

--- a/template/transaction/partial/table.html
+++ b/template/transaction/partial/table.html
@@ -1,0 +1,21 @@
+{% import 'transaction/partial/row.html' as rows %}
+{% include 'transaction/partial/daterange.html' with context %}
+
+<table>
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Description</th>
+      <th>Amount</th>
+      <th>&nbsp;</th>
+      <th>&nbsp;</th>
+    </tr>
+    <tbody id="transaction_rows" hx-target="closest tr" hx-swap="outerHTML">
+      {% if transactions %}
+        {% for transaction in transactions %}
+          {{ rows.transaction_row(transaction.tid, transaction.date, transaction.description, transaction.amount) }}
+        {% endfor %}
+      {% endif %}
+    </tbody>
+  </thead>
+</table>


### PR DESCRIPTION
Create links from index (root)

Give transaction page a cleanly rendered index.html and move the table
into a partial of its own.